### PR TITLE
test: agregar casos de cobertura para Parser (T-26 JOSE DIONICIO)

### DIFF
--- a/tests/org/umg/compilerjava/tests/ParserTests.java
+++ b/tests/org/umg/compilerjava/tests/ParserTests.java
@@ -1,6 +1,8 @@
 package org.umg.compilerjava.tests;
 
+import org.umg.compilerjava.compiler.CompilerException;
 import org.umg.compilerjava.compiler.ConditionNode;
+import org.umg.compilerjava.compiler.ExpressionNode;
 import org.umg.compilerjava.compiler.Lexer;
 import org.umg.compilerjava.compiler.Parser;
 import org.umg.compilerjava.compiler.SelectNode;
@@ -10,11 +12,17 @@ public final class ParserTests {
     public void run() {
         parsesSelectWithColumns();
         parsesWhereCondition();
+        parsesSelectAllWithoutWhere();
+        parsesWhereWithStringLiteral();
+        parsesWhereWithEqualOperator();
+        parsesQueryWithoutSemicolon();
+        throwsErrorWhenMissingFrom();
+        throwsErrorWhenInvalidExpression();
     }
 
     private void parsesSelectWithColumns() {
         SelectNode ast = new Parser(new Lexer("SELECT nombre, edad FROM usuarios;").tokenize()).parse();
-        Assert.isFalse(ast.isSelectAll(), "No debe marcar selectAll en lista explícita");
+        Assert.isFalse(ast.isSelectAll(), "No debe marcar selectAll en lista explicita");
         Assert.equals("usuarios", ast.getTableName(), "Debe extraer tabla");
         Assert.equals(2, ast.getColumns().size(), "Debe extraer dos columnas");
     }
@@ -25,5 +33,54 @@ public final class ParserTests {
         Assert.isTrue(ast.isSelectAll(), "SELECT * debe marcar selectAll");
         Assert.equals("edad", condition.getLeft().getValue(), "Debe extraer identificador izquierdo");
         Assert.equals("18", condition.getRight().getValue(), "Debe extraer literal derecho");
+    }
+
+    private void parsesSelectAllWithoutWhere() {
+        SelectNode ast = new Parser(new Lexer("SELECT * FROM productos;").tokenize()).parse();
+        Assert.isTrue(ast.isSelectAll(), "Debe marcar selectAll con asterisco");
+        Assert.equals("productos", ast.getTableName(), "Debe extraer tabla productos");
+        Assert.isTrue(ast.getWhereCondition() == null, "No debe tener condicion WHERE");
+    }
+
+    private void parsesWhereWithStringLiteral() {
+        SelectNode ast = new Parser(new Lexer("SELECT nombre FROM usuarios WHERE ciudad = 'Roma';").tokenize()).parse();
+        ConditionNode condition = ast.getWhereCondition();
+        Assert.equals("ciudad", condition.getLeft().getValue(), "Lado izquierdo debe ser ciudad");
+        Assert.equals(ExpressionNode.ExprType.STRING, condition.getRight().getType(), "Lado derecho debe ser STRING");
+        Assert.equals("Roma", condition.getRight().getValue(), "Valor derecho debe ser Roma");
+    }
+
+    private void parsesWhereWithEqualOperator() {
+        SelectNode ast = new Parser(new Lexer("SELECT * FROM usuarios WHERE id = 1;").tokenize()).parse();
+        ConditionNode condition = ast.getWhereCondition();
+        Assert.equals("id", condition.getLeft().getValue(), "Identificador izquierdo debe ser id");
+        Assert.equals("1", condition.getRight().getValue(), "Literal derecho debe ser 1");
+        Assert.equals(ExpressionNode.ExprType.NUMBER, condition.getRight().getType(), "Lado derecho debe ser NUMBER");
+    }
+
+    private void parsesQueryWithoutSemicolon() {
+        SelectNode ast = new Parser(new Lexer("SELECT nombre FROM usuarios").tokenize()).parse();
+        Assert.equals("usuarios", ast.getTableName(), "Debe parsear sin punto y coma final");
+        Assert.equals(1, ast.getColumns().size(), "Debe extraer una columna");
+    }
+
+    private void throwsErrorWhenMissingFrom() {
+        boolean lanzo = false;
+        try {
+            new Parser(new Lexer("SELECT nombre usuarios;").tokenize()).parse();
+        } catch (CompilerException ex) {
+            lanzo = true;
+        }
+        Assert.isTrue(lanzo, "Debe lanzar CompilerException si falta FROM");
+    }
+
+    private void throwsErrorWhenInvalidExpression() {
+        boolean lanzo = false;
+        try {
+            new Parser(new Lexer("SELECT * FROM usuarios WHERE = 5;").tokenize()).parse();
+        } catch (CompilerException ex) {
+            lanzo = true;
+        }
+        Assert.isTrue(lanzo, "Debe lanzar CompilerException con expresion invalida");
     }
 }


### PR DESCRIPTION
## Tarea asignada
- Código: T-26
- Nombre: ParserTests

## Usuario de GitHub
- jdion (Jose Alexander Dionicio Cordova)

## Qué implementé
- Agregué 6 casos de prueba nuevos a la suite ParserTests para mejorar la cobertura del Parser.
- Mantuve los 2 tests originales sin modificarlos (parsesSelectWithColumns y parsesWhereCondition).
- Los nuevos casos cubren:
  - parsesSelectAllWithoutWhere: SELECT * sin cláusula WHERE.
  - parsesWhereWithStringLiteral: WHERE con literal string ('Roma').
  - parsesWhereWithEqualOperator: WHERE con operador de igualdad simple.
  - parsesQueryWithoutSemicolon: consulta sin punto y coma final (es opcional).
  - throwsErrorWhenMissingFrom: validación de error al faltar FROM.
  - throwsErrorWhenInvalidExpression: validación de error con expresión inválida.
- Importé las clases CompilerException y ExpressionNode necesarias para los nuevos asserts.

## Archivos modificados
- tests/org/umg/compilerjava/tests/ParserTests.java

## Evidencia
- [x] Compila (scripts\build.bat ejecutado sin errores)
- [x] Probado localmente (scripts\test.bat: 5 suites ejecutadas, todas pasaron)
- [x] No rompe scripts base
- [x] No modifica archivos fuera de mi tarea asignada

## Observaciones
- Se respetó el estilo del proyecto: pruebas sin JUnit, usando la clase utilitaria Assert ya existente.
- Se evitaron tildes en nombres de métodos y mensajes para mantener consistencia ASCII en el código.
- El run() ahora ejecuta 8 tests en lugar de 2.