### PR TITLE
feat: migra TokenType con metodos de categoria java Bryner Paiz

### DIFF
--- a/src/main/java/org/umg/compilerjava/compiler/TokenType.java
+++ b/src/main/java/org/umg/compilerjava/compiler/TokenType.java
@@ -18,5 +18,18 @@ public enum TokenType {
     COMMA,
     SEMICOLON,
     END_OF_FILE,
-    INVALID
+    INVALID;
+
+    public boolean isKeyword() {
+        return this == SELECT || this == FROM || this == WHERE;
+    }
+
+    public boolean isOperator() {
+        return this == EQUAL || this == GREATER || this == LESS
+            || this == GREATER_EQUAL || this == LESS_EQUAL || this == NOT_EQUAL;
+    }
+
+    public boolean isLiteral() {
+        return this == NUMBER || this == STRING;
+    }
 }


### PR DESCRIPTION

[T-06] TokenType enum - Bryner Paiz
## Tarea asignada
- Código: T-06
- Nombre: TokenType enum

## Qué implementé
- Añadido método isKeyword() para identificar palabras clave (SELECT, FROM, WHERE)
- Añadido método isOperator() para identificar operadores de comparación
- Añadido método isLiteral() para identificar literales (NUMBER, STRING)

## Archivos modificados
- src/main/java/org/umg/compilerjava/compiler/TokenType.java

## Evidencia
- [x] Compila
- [x] Probado localmente
- [x] No rompe scripts base

## Observaciones
- Migración de funcionalidad de categorización de tokens desde C++ base