### PR TITLE
[T-08] Lexer parte 2 - Marjorie Giron feat: mejora readString() con soporte de escape en Lexer parte 2

### DIFF
--- a/src/main/java/org/umg/compilerjava/compiler/Lexer.java
+++ b/src/main/java/org/umg/compilerjava/compiler/Lexer.java
@@ -167,10 +167,19 @@ public final class Lexer {
 
         advance();
         while (currentChar != '\0' && currentChar != '\'') {
-            builder.append(currentChar);
+            if (currentChar == '\\') {
+                advance();
+                if (currentChar == '\'') {
+                    builder.append('\'');
+                } else {
+                    builder.append('\\');
+                    builder.append(currentChar);
+                }
+            } else {
+                builder.append(currentChar);
+            }
             advance();
         }
-
         if (currentChar != '\'') {
             return new Token(TokenType.INVALID, builder.toString(), startLine, startColumn);
         }


### PR DESCRIPTION
## Tarea asignada
- Codigo: T-08
- Nombre: Lexer parte 2 - Strings y Operadores


## Que implemente
- Mejore readString() en Lexer.java para manejar secuencias
  de escape dentro de cadenas (por ejemplo, comilla escapada)
- El lexer ahora procesa correctamente strings con caracteres especiales


## Archivos modificados
- src/main/java/org/umg/compilerjava/compiler/Lexer.java


## Evidencia
- [x] Compila
- [x] Probado localmente
- [x] No rompe scripts base


## Observaciones
- Usuario de GitHub: [SamGMorales]