### PR TITLE
feat: implementa MainController para orquestar flujo principal

### DIFF
--- a/src/main/java/org/umg/compilerjava/Main.java
+++ b/src/main/java/org/umg/compilerjava/Main.java
@@ -6,11 +6,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import javax.swing.SwingUtilities;
-import org.umg.compilerjava.auth.InMemoryAuthService;
 import org.umg.compilerjava.compiler.CompilerFacade;
 import org.umg.compilerjava.compiler.CompilerReport;
-import org.umg.compilerjava.ui.LoginFrame;
-import org.umg.compilerjava.ui.ResultFrame;
 
 /**
  * Punto de entrada de la aplicación Java.
@@ -55,10 +52,6 @@ public final class Main {
     }
 
     private static void openGui() {
-        final InMemoryAuthService authService = new InMemoryAuthService();
-        final CompilerFacade compilerFacade = new CompilerFacade();
-        final ResultFrame resultFrame = new ResultFrame(compilerFacade);
-        LoginFrame loginFrame = new LoginFrame(authService, resultFrame);
-        loginFrame.setVisible(true);
+        new MainController().start();
     }
 }

--- a/src/main/java/org/umg/compilerjava/MainController.java
+++ b/src/main/java/org/umg/compilerjava/MainController.java
@@ -1,0 +1,28 @@
+package org.umg.compilerjava;
+
+import org.umg.compilerjava.auth.InMemoryAuthService;
+import org.umg.compilerjava.compiler.CompilerFacade;
+import org.umg.compilerjava.ui.LoginFrame;
+import org.umg.compilerjava.ui.ResultFrame;
+
+/**
+ * Coordina la inicialización y el flujo entre login, compilador y vistas.
+ */
+public final class MainController {
+
+    private final InMemoryAuthService authService;
+    private final CompilerFacade compilerFacade;
+    private final ResultFrame resultFrame;
+    private final LoginFrame loginFrame;
+
+    public MainController() {
+        authService = new InMemoryAuthService();
+        compilerFacade = new CompilerFacade();
+        resultFrame = new ResultFrame(compilerFacade);
+        loginFrame = new LoginFrame(authService, resultFrame);
+    }
+
+    public void start() {
+        loginFrame.setVisible(true);
+    }
+}


### PR DESCRIPTION
Extrae la lógica de coordinación de Main.openGui() a MainController, separando responsabilidades entre el punto de entrada y la inicialización de servicios y vistas.

## Tarea asignada

- Código de tarea: T-28
- Nombre de tarea:MainController / flujo principal

## Qué implementé
- Clase `MainController` que centraliza la coordinación entre `InMemoryAuthService`, `CompilerFacade`, `ResultFrame` y `LoginFrame`
- Simplificación de `Main.openGui()` para delegar toda la lógica al `MainController`
- Eliminación de imports innecesarios en `Main.java`

## Archivos modificados
- `src/main/java/org/umg/compilerjava/MainController.java` (nuevo)
- `src/main/java/org/umg/compilerjava/Main.java` (modificado)


## Archivos modificados

-

## Evidencia

- [ ] Compila
- [ ] Probado localmente
- [ ] No rompe scripts base

## Observaciones

-
