### PR TITLE
T-07 Lexer parte 1

### DIFF
--- a/src/main/java/org/umg/compilerjava/compiler/Lexer.java
+++ b/src/main/java/org/umg/compilerjava/compiler/Lexer.java
@@ -1,12 +1,17 @@
 package org.umg.compilerjava.compiler;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Analizador léxico manual, inspirado directamente en la versión C++ educativa.
  */
 public final class Lexer {
+
+    private static final Map<String, TokenType> KEYWORDS = createKeywords();
 
     private final String source;
     private int position;
@@ -42,7 +47,7 @@ public final class Lexer {
         int startLine = line;
         int startColumn = column;
 
-        if (Character.isLetter(currentChar) || currentChar == '_') {
+        if (isIdentifierStart(currentChar)) {
             return readIdentifierOrKeyword();
         }
 
@@ -119,21 +124,15 @@ public final class Lexer {
         int startColumn = column;
         StringBuilder builder = new StringBuilder();
 
-        while (currentChar != '\0' && (Character.isLetterOrDigit(currentChar) || currentChar == '_')) {
+        while (isIdentifierPart(currentChar)) {
             builder.append(currentChar);
             advance();
         }
 
         String value = builder.toString();
-        String upper = value.toUpperCase();
-        if ("SELECT".equals(upper)) {
-            return new Token(TokenType.SELECT, value, startLine, startColumn);
-        }
-        if ("FROM".equals(upper)) {
-            return new Token(TokenType.FROM, value, startLine, startColumn);
-        }
-        if ("WHERE".equals(upper)) {
-            return new Token(TokenType.WHERE, value, startLine, startColumn);
+        TokenType keywordType = KEYWORDS.get(value.toUpperCase(Locale.ROOT));
+        if (keywordType != null) {
+            return new Token(keywordType, value, startLine, startColumn);
         }
         return new Token(TokenType.IDENTIFIER, value, startLine, startColumn);
     }
@@ -197,5 +196,21 @@ public final class Lexer {
             return '\0';
         }
         return source.charAt(nextPosition);
+    }
+
+    private static boolean isIdentifierStart(char value) {
+        return Character.isLetter(value) || value == '_';
+    }
+
+    private static boolean isIdentifierPart(char value) {
+        return Character.isLetterOrDigit(value) || value == '_';
+    }
+
+    private static Map<String, TokenType> createKeywords() {
+        Map<String, TokenType> keywords = new HashMap<String, TokenType>();
+        keywords.put("SELECT", TokenType.SELECT);
+        keywords.put("FROM", TokenType.FROM);
+        keywords.put("WHERE", TokenType.WHERE);
+        return keywords;
     }
 }

--- a/src/main/java/org/umg/compilerjava/compiler/Lexer.java
+++ b/src/main/java/org/umg/compilerjava/compiler/Lexer.java
@@ -52,7 +52,7 @@ public final class Lexer {
         }
 
         if (Character.isDigit(currentChar)) {
-            return readNumber();
+            return readNumberToken();
         }
 
         if (currentChar == '\'') {
@@ -137,7 +137,7 @@ public final class Lexer {
         return new Token(TokenType.IDENTIFIER, value, startLine, startColumn);
     }
 
-    private Token readNumber() {
+    private Token readNumberToken() {
         int startLine = line;
         int startColumn = column;
         StringBuilder builder = new StringBuilder();

--- a/tests/org/umg/compilerjava/tests/LexerTests.java
+++ b/tests/org/umg/compilerjava/tests/LexerTests.java
@@ -10,6 +10,7 @@ public final class LexerTests {
     public void run() {
         tokenizesBasicQuery();
         supportsCommentsAndStrings();
+        recognizesKeywordsIdentifiersAndIntegers();
     }
 
     private void tokenizesBasicQuery() {
@@ -25,5 +26,20 @@ public final class LexerTests {
         List<Token> tokens = new Lexer("-- comentario\nSELECT nombre FROM usuarios WHERE ciudad = 'Roma';").tokenize();
         Assert.equals(TokenType.SELECT, tokens.get(0).getType(), "Debe ignorar comentarios");
         Assert.equals(TokenType.STRING, tokens.get(7).getType(), "Debe reconocer strings");
+    }
+
+    private void recognizesKeywordsIdentifiersAndIntegers() {
+        List<Token> tokens = new Lexer("select user_name FROM usuarios WHERE edad = 18;").tokenize();
+        Assert.equals(TokenType.SELECT, tokens.get(0).getType(), "Debe reconocer SELECT sin importar mayusculas");
+        Assert.equals("select", tokens.get(0).getValue(), "Debe preservar el lexema original del keyword");
+        Assert.equals(TokenType.IDENTIFIER, tokens.get(1).getType(), "Debe reconocer identificadores con guion bajo");
+        Assert.equals("user_name", tokens.get(1).getValue(), "Debe conservar el identificador completo");
+        Assert.equals(TokenType.FROM, tokens.get(2).getType(), "Debe reconocer FROM");
+        Assert.equals(TokenType.IDENTIFIER, tokens.get(3).getType(), "Debe reconocer nombres de tabla");
+        Assert.equals(TokenType.WHERE, tokens.get(4).getType(), "Debe reconocer WHERE");
+        Assert.equals(TokenType.IDENTIFIER, tokens.get(5).getType(), "Debe reconocer nombres de columna");
+        Assert.equals(TokenType.EQUAL, tokens.get(6).getType(), "Debe reconocer =");
+        Assert.equals(TokenType.NUMBER, tokens.get(7).getType(), "Debe reconocer enteros");
+        Assert.equals("18", tokens.get(7).getValue(), "Debe conservar el valor numerico");
     }
 }


### PR DESCRIPTION
## Tarea asignada
- Código: T-07
- Nombre: Lexer parte 1

## Qué implementé
- se dejó explícita la parte del lexer encargada de reconocer números mediante el método `readNumberToken()`
- se reforzó la validación del lexer con pruebas para palabras clave SQL (`SELECT`, `FROM`, `WHERE`)
- se agregaron pruebas para identificadores válidos con guion bajo, por ejemplo `user_name`
- se agregaron pruebas para números enteros, verificando que el lexer conserve correctamente el valor leído
- se validó que las palabras clave se reconozcan sin importar mayúsculas o minúsculas

## Archivos modificados
- `src/main/java/org/umg/compilerjava/compiler/Lexer.java`
- `tests/org/umg/compilerjava/tests/LexerTests.java`

## Evidencia
- [x] Compila
- [x] Probado localmente
- [x] No rompe scripts base

## Observaciones
- la verificación se realizó con `scripts\build.bat` y `scripts\test.bat`
- las pruebas pasaron correctamente: `LexerTests`, `ParserTests`, `SemanticAnalyzerTests`, `AuthServiceTests` y `CompilerFacadeTests`
- para probar consultas SQL en ejecución, se debe usar `Main` con un archivo `.sql` como argumento, ya que escribir `SELECT ...` directo en PowerShell lo interpreta como comando del sistema
