### PR TITLE
[T-18] SymbolTable Column/DataType - José Pablo Carías

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,19 @@
+# Cambios realizados - T-18 SymbolTable Column/DataType
+## Autor: José Pablo Carías Flores
+
+## Archivos modificados
+
+### DataType.java
+- Se agregaron los tipos de datos BOOLEAN y DATE al enum
+- El enum ahora contiene: INT, FLOAT, VARCHAR, BOOLEAN, DATE
+
+### Column.java
+- Se agregó el campo nullable (boolean)
+- Se agregó constructor overload Column(String, DataType) con nullable = true por defecto
+- Se agregó constructor completo Column(String, DataType, boolean)
+- Se agregó método isNullable()
+- Se agregó método toString()
+
+## Evidencia
+- Build: exitoso
+- Tests: 5 suites ejecutadas, todas pasaron

--- a/src/main/java/org/umg/compilerjava/compiler/Column.java
+++ b/src/main/java/org/umg/compilerjava/compiler/Column.java
@@ -2,13 +2,14 @@ package org.umg.compilerjava.compiler;
 
 /** Columna del schema de base de datos. */
 public final class Column {
-
     private final String name;
     private final DataType type;
+    private final boolean nullable;
 
-    public Column(String name, DataType type) {
+    public Column(String name, DataType type, boolean nullable) {
         this.name = name;
         this.type = type;
+        this.nullable = nullable;
     }
 
     public String getName() {
@@ -18,4 +19,15 @@ public final class Column {
     public DataType getType() {
         return type;
     }
+
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    @Override
+    public String toString() {
+        return "Column{name='" + name + "', type=" + type + ", nullable=" + nullable + "}";
+    }
 }
+
+

--- a/src/main/java/org/umg/compilerjava/compiler/Column.java
+++ b/src/main/java/org/umg/compilerjava/compiler/Column.java
@@ -6,6 +6,12 @@ public final class Column {
     private final DataType type;
     private final boolean nullable;
 
+    public Column(String name, DataType type) {
+        this.name = name;
+        this.type = type;
+        this.nullable = true;
+    }
+
     public Column(String name, DataType type, boolean nullable) {
         this.name = name;
         this.type = type;
@@ -29,5 +35,3 @@ public final class Column {
         return "Column{name='" + name + "', type=" + type + ", nullable=" + nullable + "}";
     }
 }
-
-

--- a/src/main/java/org/umg/compilerjava/compiler/DataType.java
+++ b/src/main/java/org/umg/compilerjava/compiler/DataType.java
@@ -4,5 +4,8 @@ package org.umg.compilerjava.compiler;
 public enum DataType {
     INT,
     FLOAT,
-    VARCHAR
+    VARCHAR,
+    BOOLEAN,
+    DATE
 }
+


### PR DESCRIPTION
## Tarea asignada
- Código: T-18
- Nombre: SymbolTable Column/DataType

## Qué implementé
- Enum DataType con los tipos: INT, FLOAT, VARCHAR, BOOLEAN, DATE
- Clase Column con nombre, tipo de dato y si acepta nulos (nullable)
- Constructor overload Column(String, DataType) que asume nullable = true
- Método toString() en Column

## Archivos modificados
- src/main/java/org/umg/compilerjava/compiler/DataType.java
- src/main/java/org/umg/compilerjava/compiler/Column.java

## Evidencia
- [x] Compila
- [x] Probado localmente
- [x] No rompe scripts base

## Observaciones
- Se agregaron BOOLEAN y DATE al enum DataType
- Se agregó el campo nullable y toString() a Column
- Se corrigió error de compilación agregando constructor overload